### PR TITLE
makefile: respect PREFIX, LIBDIR and DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PREFIX ?= /usr/local
 LIBDIR ?= /lib
 
 clientbuffer.so : clientbuffer.cpp
-	znc-buildmod clientbuffer.cpp
+	$(PREFIX)/bin/znc-buildmod clientbuffer.cpp
 
 install: clientbuffer.so
 	install -Dm 755 clientbuffer.so $(DESTDIR)$(PREFIX)$(LIBDIR)/znc/clientbuffer.so

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,15 @@
 PREFIX ?= /usr/local
 LIBDIR ?= /lib
 
-clientbuffer.so : clientbuffer.cpp
+clientbuffer.so : clientbuffer.cpp $(PREFIX)/bin/znc-buildmod
 	$(PREFIX)/bin/znc-buildmod clientbuffer.cpp
 
 install: clientbuffer.so
 	install -Dm 755 clientbuffer.so $(DESTDIR)$(PREFIX)$(LIBDIR)/znc/clientbuffer.so
+
+$(PREFIX)/bin/znc-buildmod :
+	@echo "Did not find a znc-buildmod binary at $(PREFIX)/bin/znc-buildmod."
+	@echo "Is PREFIX corretly set? ($(PREFIX))"
+	@if [ "$(PREFIX)" = /usr ] ; then echo "Maybe try rerunning with PREFIX=/usr/local" ; fi
+	@if [ "$(PREFIX)" = /usr/local ] ; then echo "Maybe try rerunning with PREFIX=/usr" ; fi
+	@exit 1

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
+PREFIX ?= /usr/local
+LIBDIR ?= /lib
+
 clientbuffer.so : clientbuffer.cpp
 	znc-buildmod clientbuffer.cpp
 
 install: clientbuffer.so
-	install clientbuffer.so /usr/lib/znc/
+	install -Dm 755 clientbuffer.so $(DESTDIR)$(PREFIX)$(LIBDIR)/znc/clientbuffer.so


### PR DESCRIPTION
This allows distributions to properly build packages.

Signed-off-by: Filipe Laíns <lains@archlinux.org>