### PR TITLE
Refactor AddClient method to handle time limit

### DIFF
--- a/clientbuffer.cpp
+++ b/clientbuffer.cpp
@@ -445,7 +445,10 @@ CModule::EModRet CClientBufferMod::OnPrivBufferPlayLine2(CClient& client, CStrin
 bool CClientBufferMod::AddClient(const CString& identifier)
 {
     m_bDirty = true;
-    return SetNV(identifier, "", false);
+    bool ok = SetNV(identifier, "", false);
+    if (ok && m_iTimeLimit)
+        SetNV(identifier + "/timelimit", CString(m_iTimeLimit), false);
+    return ok;
 }
 
 /// Remove a client identifier.
@@ -606,7 +609,7 @@ bool CClientBufferMod::WithinTimeLimit(const timeval& tv, const CString& identif
 		return true;
 	timeval now;
 	gettimeofday(&now, NULL);
-	return now.tv_sec - tv.tv_sec < timeLimit ? timeLimit : m_iTimeLimit;
+	return now.tv_sec - tv.tv_sec < (timeLimit ? timeLimit : m_iTimeLimit);
 }
 
 template<> void TModInfo<CClientBufferMod>(CModInfo& info) {


### PR DESCRIPTION
fix: two bugs related to timelimit handling

- WithinTimeLimit: fix operator precedence in ternary expression. `now.tv_sec - tv.tv_sec < timeLimit ? timeLimit : m_iTimeLimit` was parsed as `(... < timeLimit) ? timeLimit : m_iTimeLimit`, always returning a truthy integer instead of a bool comparison. Added parentheses to enforce the intended logic.

- AddClient: when a module-level timelimit is configured via the `timelimit=` load argument, persist it into the NV store for newly added clients. Previously, m_iTimeLimit was silently used as a fallback in WithinTimeLimit but never stored, causing ListClients to always show a blank TimeLimit column even when the limit was active.